### PR TITLE
Fix: src/library.c:127: undefined reference to `strlen'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS  += -g -O2 -fPIC -pie -Wall -fno-stack-protector -fvisibility=hidden
+CFLAGS  += -g -O2 -fPIC -pie -Wall -fno-stack-protector -fvisibility=hidden -fno-builtin
 LDFLAGS += -fPIC -pie -static -nostdlib -Wl,-z,relro -Wl,-z,initfirst -Wl,-e_start
 
 DEPS    = $(wildcard src/*.h)


### PR DESCRIPTION
```
cc src/cpuid.o src/library.o src/loader.o src/syscalls.o -fPIC -pie -static -nostdlib -Wl,-z,relro -Wl,-z,initfirst -Wl,-e_start -o libcpuidoverride.so
/usr/bin/ld: src/library.o: in function `my_strlen':
/tmp/libcpuidoverride/src/library.c:128: undefined reference to `strlen'
/usr/bin/ld: /tmp/libcpuidoverride/src/library.c:128: undefined reference to `strlen'
/usr/bin/ld: /tmp/libcpuidoverride/src/library.c:128: undefined reference to `strlen'
collect2: error: ld returned 1 exit status
```
